### PR TITLE
Added rule to load after Vanilla Expanded Framework

### DIFF
--- a/About/About.xml
+++ b/About/About.xml
@@ -16,6 +16,9 @@
 			<steamWorkshopUrl>https://steamcommunity.com/sharedfiles/filedetails/?id=1718190143</steamWorkshopUrl>
 		</li>
 	</modDependencies>
+	<loadAfter>
+		<li>OskarPotocki.VanillaFactionsExpanded.Core</li>
+	</loadAfter>
 	<description>Vanilla Furniture Expanded - Spacer module adds several new pieces of furniture to allow players to witness better technological progress in regards to comfort and utility furniture. Repair shelves, Biolab sunlamps and reinforced walls will spice your colony up, whilst illuminated dressers and end tables as well as advanced beds will provide your pawns with highest possible comfort silver can buy.
   </description>
 </ModMetaData>


### PR DESCRIPTION
I've changed `About.xml` file to add a rule to make this mod load after Vanilla Expanded Framework.

This mod relies on loading after VEF due to the VEF prepatches - it will cause an error and break Royalty compatibility if loaded before those are applied.

This change won't fix the issue if the mod ends up loaded before VEF - however, this should help lower the chances someone will do that by accident, as auto-sorting mods should now properly place this mod in the correct location. It will also let people with incorrect load order know that it's incorrect if they check their mod list.

The error in question if the mod is loaded before VEF:
```
[Vanilla Furniture Expanded - Spacer Module] Patch operation Verse.PatchOperationFindMod(Royalty) failed
file: C:\Program Files (x86)\Steam\steamapps\common\RimWorld\Mods\VanillaFurnitureExpanded-Spacer\1.5\Patches\Royalty.xml 
```

The prepatches this relies on: https://github.com/Vanilla-Expanded/VanillaExpandedFramework/blob/main/1.5/Patches/Royalty/Royalty_PrePatches.xml